### PR TITLE
Optimize SQL storage method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.idea/
+*.iml
+target/
+dependency-reduced-pom.xml

--- a/src/main/java/co/melondev/Snitch/commands/SnitchCommand.java
+++ b/src/main/java/co/melondev/Snitch/commands/SnitchCommand.java
@@ -70,7 +70,7 @@ public class SnitchCommand implements CommandExecutor {
 
             } catch (IllegalArgumentException ex) {
                 sender.sendMessage(MsgUtil.error(ex.getMessage()));
-            } catch (SQLException e) {
+            } catch (Exception e) {
                 sender.sendMessage(MsgUtil.error("Internal database error. Check console for details."));
                 e.printStackTrace();
             }

--- a/src/main/java/co/melondev/Snitch/entities/SnitchEntry.java
+++ b/src/main/java/co/melondev/Snitch/entities/SnitchEntry.java
@@ -32,7 +32,7 @@ public class SnitchEntry {
         this.reverted = reverted;
     }
 
-    public SnitchEntry(ResultSet set) throws SQLException {
+    public SnitchEntry(ResultSet set) throws Exception {
         this.id = set.getInt("id");
         this.action = EnumAction.getById(set.getInt("action_id"));
         this.snitchPlayer = SnitchPlugin.getInstance().getStorage().getPlayer(set.getInt("player_id"));

--- a/src/main/java/co/melondev/Snitch/entities/SnitchPreview.java
+++ b/src/main/java/co/melondev/Snitch/entities/SnitchPreview.java
@@ -126,7 +126,7 @@ public class SnitchPreview implements Previewable {
                                         SnitchPlugin.getInstance().async(() -> {
                                             try {
                                                 SnitchPlugin.getInstance().getStorage().markReverted(entry, true);
-                                            } catch (SQLException e) {
+                                            } catch (Exception e) {
                                                 e.printStackTrace();
                                             }
                                         });
@@ -134,7 +134,7 @@ public class SnitchPreview implements Previewable {
                                         SnitchPlugin.getInstance().async(() -> {
                                             try {
                                                 SnitchPlugin.getInstance().getStorage().markReverted(entry, false);
-                                            } catch (SQLException e) {
+                                            } catch (Exception e) {
                                                 e.printStackTrace();
                                             }
                                         });

--- a/src/main/java/co/melondev/Snitch/entities/SnitchQuery.java
+++ b/src/main/java/co/melondev/Snitch/entities/SnitchQuery.java
@@ -53,7 +53,7 @@ public class SnitchQuery {
         return this;
     }
 
-    public SnitchQuery inWorld(World world) throws SQLException {
+    public SnitchQuery inWorld(World world) throws Exception {
         return inWorld(SnitchPlugin.getInstance().getStorage().register(world));
     }
 
@@ -146,7 +146,7 @@ public class SnitchQuery {
         return EnumParam.getByKeyword(s) != null;
     }
 
-    public boolean parseParams(Player player, List<String> arguments) throws SQLException {
+    public boolean parseParams(Player player, List<String> arguments) throws Exception {
 
         if (arguments.isEmpty()) {
             throw new IllegalArgumentException("No params specified.");

--- a/src/main/java/co/melondev/Snitch/enums/EnumDefaultPlayer.java
+++ b/src/main/java/co/melondev/Snitch/enums/EnumDefaultPlayer.java
@@ -25,7 +25,7 @@ public enum EnumDefaultPlayer {
         this.uuid = UUID.fromString(uuid);
     }
 
-    public SnitchPlayer getSnitchPlayer() throws SQLException {
+    public SnitchPlayer getSnitchPlayer() throws Exception {
         return SnitchPlugin.getInstance().getStorage().getPlayer(getStorageName());
     }
 

--- a/src/main/java/co/melondev/Snitch/enums/EnumParam.java
+++ b/src/main/java/co/melondev/Snitch/enums/EnumParam.java
@@ -25,7 +25,7 @@ public enum EnumParam {
 
     PLAYER(Arrays.asList("player", "players", "p"), "player Turqmelon") {
         @Override
-        public void parse(Player player, SnitchQuery query, String[] values) throws SQLException {
+        public void parse(Player player, SnitchQuery query, String[] values) throws Exception {
             for (String playerName : values) {
                 SnitchPlayer pl = SnitchPlugin.getInstance().getStorage().getPlayer(playerName);
                 Validate.notNull(pl, "Unknown player: " + playerName);
@@ -35,7 +35,7 @@ public enum EnumParam {
     },
     ACTION(Arrays.asList("action", "actions", "a"), "action break") {
         @Override
-        public void parse(Player player, SnitchQuery query, String[] values) throws SQLException {
+        public void parse(Player player, SnitchQuery query, String[] values) {
             for (String action : values) {
                 List<EnumAction> results = EnumAction.getByName(action);
                 Validate.notEmpty(results, "Unknown action: " + action);
@@ -47,7 +47,7 @@ public enum EnumParam {
     },
     SINCE(Arrays.asList("since", "from", "s"), "since 1d") {
         @Override
-        public void parse(Player player, SnitchQuery query, String[] values) throws SQLException {
+        public void parse(Player player, SnitchQuery query, String[] values) {
             Validate.notEmpty(values, "No time specified for " + name() + ".");
             Validate.isTrue(values.length == 1, "Multiple time values provided for " + name() + ".");
             query.setSinceTime(EnumParam.getUnixTime(values[0], false));
@@ -55,7 +55,7 @@ public enum EnumParam {
     },
     BEFORE(Arrays.asList("before", "prior", "b"), "before 06/12/18") {
         @Override
-        public void parse(Player player, SnitchQuery query, String[] values) throws SQLException {
+        public void parse(Player player, SnitchQuery query, String[] values) {
             Validate.notEmpty(values, "No time specified for " + name() + ".");
             Validate.isTrue(values.length == 1, "Multiple time values provided for " + name() + ".");
             query.setBeforeTime(EnumParam.getUnixTime(values[0], false));
@@ -63,7 +63,7 @@ public enum EnumParam {
     },
     WORLD(Arrays.asList("world", "w"), "world world_nether") {
         @Override
-        public void parse(Player player, SnitchQuery query, String[] values) throws SQLException {
+        public void parse(Player player, SnitchQuery query, String[] values) throws Exception {
             Validate.notEmpty(values, "No world specified.");
             Validate.isTrue(values.length == 1, "Multiple world values provided.");
             World world = Bukkit.getWorld(values[0]);
@@ -74,7 +74,7 @@ public enum EnumParam {
     },
     COORDS(Arrays.asList("coords", "relative", "pos", "position"), "relative 100 150 100") {
         @Override
-        public void parse(Player player, SnitchQuery query, String[] values) throws SQLException {
+        public void parse(Player player, SnitchQuery query, String[] values) throws Exception {
             Validate.isTrue(values.length == 3, "Specify an x, y, and z value.");
             try {
                 int x = Integer.parseInt(values[0]);
@@ -91,7 +91,7 @@ public enum EnumParam {
     },
     RADIUS(Arrays.asList("area", "radius", "range"), "area 20") {
         @Override
-        public void parse(Player player, SnitchQuery query, String[] values) throws SQLException {
+        public void parse(Player player, SnitchQuery query, String[] values) throws Exception {
             Validate.notEmpty(values, "No range specified.");
             Validate.isTrue(values.length == 1, "Multiple range values specified.");
             try {
@@ -151,6 +151,6 @@ public enum EnumParam {
         return keywords;
     }
 
-    public abstract void parse(Player player, SnitchQuery query, String[] values) throws SQLException;
+    public abstract void parse(Player player, SnitchQuery query, String[] values) throws Exception;
 
 }

--- a/src/main/java/co/melondev/Snitch/enums/EnumSnitchCommand.java
+++ b/src/main/java/co/melondev/Snitch/enums/EnumSnitchCommand.java
@@ -27,7 +27,7 @@ public enum EnumSnitchCommand {
 
     ACTIONS(Arrays.asList("actions", "a"), "", "View list of actions", "snitch.actions") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) {
             List<String> generals = new ArrayList<>();
             List<String> fullNames = new ArrayList<>();
             for (EnumAction action : EnumAction.values()) {
@@ -42,7 +42,7 @@ public enum EnumSnitchCommand {
     },
     PARAMS(Arrays.asList("params", "p"), "", "View list of params", "snitch.params") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) {
             sender.sendMessage(MsgUtil.info("Params"));
             StringBuilder lookupExample = new StringBuilder();
             StringBuilder rollbackExample = new StringBuilder();
@@ -62,7 +62,7 @@ public enum EnumSnitchCommand {
     },
     ROLLBACK(Arrays.asList("rollback", "rb"), "<params>", "Perform a rollback", "snitch.rollback") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) throws Exception {
             if ((sender instanceof Player)) {
                 Player player = (Player) sender;
 
@@ -82,7 +82,7 @@ public enum EnumSnitchCommand {
     },
     RESTORE(Arrays.asList("restore", "rs"), "<params>", "Restore changes from a rollback", "snitch.restore") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) throws Exception {
             if ((sender instanceof Player)) {
                 Player player = (Player) sender;
 
@@ -102,7 +102,7 @@ public enum EnumSnitchCommand {
     },
     PREVIEW(Arrays.asList("preview", "pv"), "<params>", "Perform a rollback preview", "snitch.preview") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) throws Exception {
             if ((sender instanceof Player)) {
                 Player player = (Player) sender;
                 if (args.size() == 1) {
@@ -148,7 +148,7 @@ public enum EnumSnitchCommand {
     },
     LOOKUP(Arrays.asList("lookup", "l"), "<params>", "Perform a lookup", "snitch.lookup") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) throws Exception {
             if ((sender instanceof Player)) {
 
                 Player player = (Player) sender;
@@ -165,7 +165,7 @@ public enum EnumSnitchCommand {
     },
     NEAR(Arrays.asList("near"), "[range]", "Perform a quick area lookup", "snitch.near") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) throws Exception {
             if ((sender instanceof Player)) {
 
                 Player player = (Player) sender;
@@ -195,7 +195,7 @@ public enum EnumSnitchCommand {
     },
     TELEPORT(Arrays.asList("teleport", "tp"), "<#>", "Teleport to a log entry", "snitch.teleport") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) {
             if ((sender instanceof Player)) {
 
                 if (args.size() == 1) {
@@ -252,7 +252,7 @@ public enum EnumSnitchCommand {
     },
     NEXT(Arrays.asList("next"), "", "Go to next page", "snitch.lookup") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) {
             if ((sender instanceof Player)) {
                 Player player = (Player) sender;
                 SnitchSession session = SnitchPlugin.getInstance().getPlayerManager().getSession(player);
@@ -271,7 +271,7 @@ public enum EnumSnitchCommand {
     },
     PREVIOUS(Arrays.asList("prev"), "", "Go to previous page", "snitch.lookup") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) {
             if ((sender instanceof Player)) {
                 Player player = (Player) sender;
                 SnitchSession session = SnitchPlugin.getInstance().getPlayerManager().getSession(player);
@@ -295,7 +295,7 @@ public enum EnumSnitchCommand {
     },
     PAGE(Arrays.asList("page", "pv"), "<page>", "Go to specific page", "snitch.lookup") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) {
             if ((sender instanceof Player)) {
                 Player player = (Player) sender;
                 Validate.isTrue(args.size() == 1, "Specify page number.");
@@ -316,7 +316,7 @@ public enum EnumSnitchCommand {
     },
     DRAIN(Arrays.asList("drain", "dr"), "[radius]", "Drain liquids", "snitch.drain") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) {
             if ((sender instanceof Player)) {
 
                 Player player = (Player) sender;
@@ -347,7 +347,7 @@ public enum EnumSnitchCommand {
     },
     EXTINGUISH(Arrays.asList("extinguish", "ex"), "[radius]", "Extinguish fires", "snitch.extinguish") {
         @Override
-        public void run(CommandSender sender, List<String> args) throws SQLException {
+        public void run(CommandSender sender, List<String> args) {
             if ((sender instanceof Player)) {
 
                 Player player = (Player) sender;
@@ -410,7 +410,7 @@ public enum EnumSnitchCommand {
         return null;
     }
 
-    public abstract void run(CommandSender sender, List<String> args) throws SQLException;
+    public abstract void run(CommandSender sender, List<String> args) throws Exception;
 
     public List<String> getCommands() {
         return commands;

--- a/src/main/java/co/melondev/Snitch/handlers/ChatListener.java
+++ b/src/main/java/co/melondev/Snitch/handlers/ChatListener.java
@@ -44,7 +44,7 @@ public class ChatListener implements Listener {
                     d.addProperty("message", ChatColor.stripColor(message));
                 }
                 i.getStorage().record(action, snitchPlayer, world, position, d, System.currentTimeMillis());
-            } catch (SQLException ex) {
+            } catch (Exception ex) {
                 ex.printStackTrace();
             }
         });

--- a/src/main/java/co/melondev/Snitch/listeners/ConnectionListener.java
+++ b/src/main/java/co/melondev/Snitch/listeners/ConnectionListener.java
@@ -17,7 +17,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
-import java.sql.SQLException;
 import java.util.UUID;
 
 /**
@@ -38,7 +37,7 @@ public class ConnectionListener implements Listener {
                 SnitchWorld world = i.getStorage().register(location.getWorld());
                 SnitchPosition position = new SnitchPosition(location);
                 i.getStorage().record(action, snitchPlayer, world, position, data, System.currentTimeMillis());
-            } catch (SQLException ex) {
+            } catch (Exception ex) {
                 ex.printStackTrace();
             }
         });
@@ -81,7 +80,7 @@ public class ConnectionListener implements Listener {
         UUID uuid = event.getUniqueId();
         try {
             i.getStorage().registerPlayer(playerName, uuid);
-        } catch (SQLException e) {
+        } catch (Exception e) {
             event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER, "Error creating your Snitch data!");
             e.printStackTrace();
         }

--- a/src/main/java/co/melondev/Snitch/listeners/EntityListener.java
+++ b/src/main/java/co/melondev/Snitch/listeners/EntityListener.java
@@ -54,7 +54,7 @@ public class EntityListener implements Listener {
                     d.add("entity", JsonUtil.jsonify(entity));
                 }
                 i.getStorage().record(action, snitchPlayer, world, position, d, System.currentTimeMillis());
-            } catch (SQLException ex) {
+            } catch (Exception ex) {
                 ex.printStackTrace();
             }
         });
@@ -76,7 +76,7 @@ public class EntityListener implements Listener {
                     d.add("entity", JsonUtil.jsonify(entity));
                 }
                 i.getStorage().record(action, snitchPlayer, world, position, d, System.currentTimeMillis());
-            } catch (SQLException ex) {
+            } catch (Exception ex) {
                 ex.printStackTrace();
             }
         });
@@ -98,7 +98,7 @@ public class EntityListener implements Listener {
                     d.add("block", JsonUtil.jsonify(block));
                 }
                 i.getStorage().record(action, snitchPlayer, world, position, d, System.currentTimeMillis());
-            } catch (SQLException ex) {
+            } catch (Exception ex) {
                 ex.printStackTrace();
             }
         });

--- a/src/main/java/co/melondev/Snitch/listeners/InventoryListener.java
+++ b/src/main/java/co/melondev/Snitch/listeners/InventoryListener.java
@@ -49,7 +49,7 @@ public class InventoryListener implements Listener {
                     d.add("item", JsonUtil.jsonify(itemStack));
                 }
                 i.getStorage().record(action, snitchPlayer, world, position, d, System.currentTimeMillis());
-            } catch (SQLException ex) {
+            } catch (Exception ex) {
                 ex.printStackTrace();
             }
         });

--- a/src/main/java/co/melondev/Snitch/managers/PlayerManager.java
+++ b/src/main/java/co/melondev/Snitch/managers/PlayerManager.java
@@ -20,7 +20,7 @@ public class PlayerManager {
         this.i = instance;
         try {
             this.registerDefaultPlayers();
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -33,7 +33,7 @@ public class PlayerManager {
         return sessionCache.getIfPresent(player.getUniqueId());
     }
 
-    private void registerDefaultPlayers() throws SQLException {
+    private void registerDefaultPlayers() throws Exception {
         for(EnumDefaultPlayer defaultPlayer : EnumDefaultPlayer.values()){
             i.getStorage().registerPlayer(defaultPlayer.getStorageName(), defaultPlayer.getUuid());
         }

--- a/src/main/java/co/melondev/Snitch/storage/StorageMethod.java
+++ b/src/main/java/co/melondev/Snitch/storage/StorageMethod.java
@@ -14,23 +14,23 @@ public interface StorageMethod {
 
     ImmutableList<SnitchWorld> getWorlds();
 
-    SnitchWorld register(World world) throws SQLException;
+    SnitchWorld register(World world) throws Exception;
 
-    SnitchPlayer registerPlayer(String playerName, UUID uuid) throws SQLException;
+    SnitchPlayer registerPlayer(String playerName, UUID uuid) throws Exception;
 
-    SnitchPlayer getPlayer(UUID uuid) throws SQLException;
+    SnitchPlayer getPlayer(UUID uuid) throws Exception;
 
-    SnitchPlayer getPlayer(String playerName) throws SQLException;
+    SnitchPlayer getPlayer(String playerName) throws Exception;
 
-    SnitchEntry record(EnumAction action, SnitchPlayer player, SnitchWorld world, SnitchPosition position, JsonObject data, long time) throws SQLException;
+    SnitchEntry record(EnumAction action, SnitchPlayer player, SnitchWorld world, SnitchPosition position, JsonObject data, long time) throws Exception;
 
-    ImmutableList<SnitchEntry> performLookup(SnitchQuery query) throws SQLException;
+    ImmutableList<SnitchEntry> performLookup(SnitchQuery query) throws Exception;
 
-    SnitchPlayer getPlayer(int playerID) throws SQLException;
+    SnitchPlayer getPlayer(int playerID) throws Exception;
 
     SnitchWorld getWorld(int worldID);
 
-    void markReverted(SnitchEntry entry, boolean reverted) throws SQLException;
+    void markReverted(SnitchEntry entry, boolean reverted) throws Exception;
 
     void closeConnection() throws IOException;
 }


### PR DESCRIPTION
- Moves all the StorageMethod SQLExceptions to Exceptions (could probably
create a LoadException class) as not every database is going to throw SQL exceptions.
- Replace cache by LoadingCache
- Removes unnecesary .concurrencyLevel(4) call (Guava already defaults
to this value)

I don't expect this to get merged, but some keypoints presented above can be implemented. I was too lazy to move everything to a custom LoadException class 😅